### PR TITLE
RDKEMW-6588: fix the coverity issue - make time_t 64bit

### DIFF
--- a/core/IARMDaemonMain-dbus.c
+++ b/core/IARMDaemonMain-dbus.c
@@ -23,7 +23,10 @@
 #include <sys/types.h>
 #include <signal.h>
 #include <unistd.h>
+
+#define _TIME_BITS 64
 #include <time.h>
+
 #include "string.h"
 
 #ifdef ENABLE_SD_NOTIFY


### PR DESCRIPTION
Reason for Change: To fix the below coverity error. Fix logic is to make it 64bit.
```
Use of 32-bit time_t
```